### PR TITLE
ci: add temporary ci to send issues and PRs to the project board

### DIFF
--- a/.github/workflows/pr-issues-project.yaml
+++ b/.github/workflows/pr-issues-project.yaml
@@ -1,0 +1,17 @@
+---
+name: Project
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+  pull_request:
+    types: [opened, reopened, closed]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/add-to-project@0.4.1
+      with:
+        project: https://github.com/orgs/camptocamp/projects/3/
+        github-token: ${{ secrets.TEMP_TOKEN }}


### PR DESCRIPTION
## Description of the changes

This is a test CI workflow for a proof of concept that allows us to centralize all our issues and PRs on a GitHub project board.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)
_Not applicable_