### PR TITLE
ci: remove App ID secret

### DIFF
--- a/.github/workflows/pr-issues-project.yaml
+++ b/.github/workflows/pr-issues-project.yaml
@@ -1,19 +1,19 @@
 ---
-  name: "pr-issues-project"
+name: "pr-issues-project"
+
+on:
+  issues:
+    types:
+    - opened
+    - reopened
   
-  on:
-    issues:
-      types: 
-      - opened
-      - reopened
-    
-    pull_request:
-      types:
-      - opened
-      - reopened
-  
-  jobs:
-    add-to-project:
-      uses: camptocamp/devops-stack/.github/workflows/pr-issues-project.yaml@main
-      secrets:
-        PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
+  pull_request:
+    types:
+    - opened
+    - reopened
+
+jobs:
+  add-to-project:
+    uses: camptocamp/devops-stack/.github/workflows/pr-issues-project.yaml@main
+    secrets:
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}

--- a/.github/workflows/pr-issues-project.yaml
+++ b/.github/workflows/pr-issues-project.yaml
@@ -6,7 +6,7 @@ on:
     types:
     - opened
     - reopened
-  
+
   pull_request:
     types:
     - opened

--- a/.github/workflows/pr-issues-project.yaml
+++ b/.github/workflows/pr-issues-project.yaml
@@ -16,6 +16,4 @@
     add-to-project:
       uses: camptocamp/devops-stack/.github/workflows/pr-issues-project.yaml@main
       secrets:
-        PROJECT_APP_ID: ${{ secrets.PROJECT_APP_ID }}
         PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
-  

--- a/README.adoc
+++ b/README.adoc
@@ -66,11 +66,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>>
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
-- [[provider_null]] <<provider_null,null>>
 
 === Resources
 
@@ -204,8 +204,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[provider_null]] <<provider_null,null>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -203,9 +203,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_null]] <<provider_null,null>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources


### PR DESCRIPTION
## Description of the changes

Remove App ID secret since it will be hardcoded on the central repository (see https://github.com/camptocamp/devops-stack/pull/991).