### PR TITLE
feat!: add support to oboukili/argocd >= v5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,14 +66,19 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = var.app_autosync
+      automated {
+        prune       = var.app_autosync.prune
+        self_heal   = var.app_autosync.self_heal
+        allow_empty = var.app_autosync.allow_empty
+      }
 
       retry {
-        backoff = {
-          duration     = ""
-          max_duration = ""
+        backoff {
+          duration     = "20s"
+          max_duration = "2m"
+          factor       = "2"
         }
-        limit = "0"
+        limit = "5"
       }
 
       sync_options = [

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source  = "oboukili/argocd"
-      version = ">= 4"
+      version = ">= 5"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

This PR adds support to the Argo CD Terraform provider version >= 5, which is needed to support versions of Argo CD >= 2.7.x.

## Breaking change

- [x] Yes (in the module itself): see https://github.com/oboukili/terraform-provider-argocd/releases/tag/v5.0.0

## Tests executed on which distribution(s)

No testing was done since this is the module template.