### PR TITLE
fix/ci: fix autosync deactivation and add chart auto-updater workflow

### DIFF
--- a/.github/workflows/chart-update.yaml
+++ b/.github/workflows/chart-update.yaml
@@ -1,0 +1,51 @@
+# In case you module has a chart that has dependencies, you can use this workflow to automate the update of the chart dependencies.
+---
+name: "chart-update"
+
+on:
+  # Do not forget to reactivate chart-update on your module. It was deactivated here to avoid running the workflow on 
+  # the template for nothing.
+  # Simply uncomment the schedule block.
+  
+  # schedule:
+  # - cron: "0 7 * * 1-5"
+  
+  workflow_dispatch:
+    inputs:
+      update-strategy:
+        description: "Update strategy to use. Valid values are 'patch', 'minor' or 'major'"
+        type: choice
+        options:
+        - "patch"
+        - "minor"
+        - "major"
+        required: true
+      excluded-dependencies:
+        description: "Comma-separated list of dependencies to exclude from the update (i.e. 'dependency1,dependency2,dependency3')"
+        type: string
+        required: false
+        default: ""
+      dry-run:
+        description: "Activate dry-run mode"
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+
+  chart-update-schedule:
+    if: ${{ github.event_name == 'schedule' }}
+    strategy:
+      matrix:
+        update-strategy: ["major", "minor"]
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ matrix.update-strategy }}
+  
+  chart-update-manual:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ inputs.update-strategy }}
+      excluded-dependencies: ${{ inputs.excluded-dependencies }}
+      dry-run: ${{ inputs.dry-run }}

--- a/README.adoc
+++ b/README.adoc
@@ -58,7 +58,7 @@ This module must be one of the first ones to be deployed and consequently it nee
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -70,7 +70,7 @@ The following providers are used by this module:
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
@@ -196,7 +196,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -206,9 +206,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = devops-stack-module-template
 // Document attributes to replace along the document
 // Here you can define variables for something that keeps repeating along the text
-:chart-version: 1.2.3
+:CHART-NAME-chart-version: 1.2.3
 :original-repo-url: https://github.com/path/to/some/repository
 
 A https://devops-stack.io[DevOps Stack] module to deploy *_something_*.

--- a/main.tf
+++ b/main.tf
@@ -66,10 +66,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {


### PR DESCRIPTION
## Description of the changes

This PR:
- re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #20. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.
- adds the workflow that enables the auto-upgrade of the Helm charts.

:warning: **Do a _Rebase and merge_**