### PR TITLE
feat: add variables to set AppProject, labels and destination cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,11 +68,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -111,6 +111,30 @@ Description: Namespace used by Argo CD where the Application and AppProject reso
 Type: `string`
 
 Default: `"argocd"`
+
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -206,9 +230,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources
@@ -244,6 +268,24 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,8 @@
 = devops-stack-module-template
 // Document attributes to replace along the document
 // Here you can define variables for something that keeps repeating along the text
-:CHART-NAME-chart-version: 1.2.3
+:CHART-DEPENDENCY-1-NAME-chart-version: 1.2.3
+:CHART-DEPENDENCY-2-NAME-chart-version: 1.2.3
 :original-repo-url: https://github.com/path/to/some/repository
 
 A https://devops-stack.io[DevOps Stack] module to deploy *_something_*.
@@ -11,7 +12,7 @@ The *_something_* chart used by this module is shipped in this repository as wel
 [cols="1,1,1",options="autowidth,header"]
 |===
 |Current Chart Version |Original Repository |Default Values
-|*{CHART-NAME-chart-version}* |{original-repo-url}/subpath/to/the/chart[Chart] |{original-repo-url}//subpath/to/the/values.yaml[`values.yaml`] (_here you can also use artifacthub.io_)
+|*{CHART-DEPENDENCY-NAME-chart-version}* |{original-repo-url}/subpath/to/the/chart[Chart] |{original-repo-url}//subpath/to/the/values.yaml[`values.yaml`] (_here you can also use artifacthub.io_)
 |===
 
 == Usage
@@ -28,10 +29,9 @@ module "template" {
   cluster_name            = local.cluster_name
   argocd_namespace        = local.argocd_namespace
 
-  # TODO Consider replacing this depends_on by our dependency_ids
-  depends_on = [
-    module.argocd_bootstrap,
-  ]
+  dependency_ids = {
+    argocd = module.argocd_bootstrap.id
+  }
 }
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ The *_something_* chart used by this module is shipped in this repository as wel
 [cols="1,1,1",options="autowidth,header"]
 |===
 |Current Chart Version |Original Repository |Default Values
-|*{CHART-DEPENDENCY-NAME-chart-version}* |{original-repo-url}/subpath/to/the/chart[Chart] |{original-repo-url}//subpath/to/the/values.yaml[`values.yaml`] (_here you can also use artifacthub.io_)
+|*{CHART-DEPENDENCY-1-NAME-chart-version}* |{original-repo-url}/subpath/to/the/chart[Chart] |{original-repo-url}/subpath/to/the/values.yaml[`values.yaml`] (_here you can also use artifacthub.io_)
 |===
 
 == Usage

--- a/charts/CHART_NAME/Chart.yaml
+++ b/charts/CHART_NAME/Chart.yaml
@@ -6,6 +6,6 @@ apiVersion: "v2"
 name: "<CHART_NAME>"
 version: "0"
 dependencies:
-  - name: "<DEPENDENCY_NAME>"
-    version: "^1" # Fix the major version only.
-    repository: "<CHART_REPO_URL>"
+- name: "<DEPENDENCY_NAME>"
+  version: "1.2.3" # Hardcode the version and the auto-upgrade workflow will change this automatically.
+  repository: "<CHART_REPO_URL>"

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 ---
 name: "template"
-title: "Module Template"
+title: "Template Module"
 version: true
 start_page: README.adoc
 nav:

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,24 @@ variable "argocd_namespace" {
   default     = "argocd"
 }
 
+variable "argocd_project" {
+  description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
+  type        = string
+  default     = null
+}
+
+variable "argocd_labels" {
+  description = "Labels to attach to the Argo CD Application resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "destination_cluster" {
+  description = "Destination cluster where the application should be deployed."
+  type        = string
+  default     = "in-cluster"
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR:

- Adds support to seet the Argo CD project, destination cluster and application labels like the modifications done throughout the other modules.
- Also makes some small modifications to the example to make it more coherent with the changes that were done to support the chart auto update workflow.

:warning: **Do a _Rebase and merge_.**